### PR TITLE
Fix font-family comments in hero.css

### DIFF
--- a/src/css/hero.css
+++ b/src/css/hero.css
@@ -14,10 +14,10 @@
 
 .hero__subtitle {
   margin-bottom: 24px;
-  /* font-family: 'Fira Sans', sans-serif;
+  font-family: 'Fira Sans', sans-serif;
   font-weight: 400;
   font-size: 16px;
-  color: #030a06; */
+  color: #030a06;
 }
 
 .hero__button {


### PR DESCRIPTION
Restores the font-family property for the hero subtitle by uncommenting it. This ensures consistent styling by applying the desired font to the subtitle text.

No other modifications were made to the CSS rules.