### PR TITLE
Add z-index to header for improved stacking context

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -132,6 +132,7 @@
   position: fixed;
   top: 0;
   left: 0;
+  z-index: 999;
   width: 100%;
   height: 100%;
   background-color: #75d281;


### PR DESCRIPTION
Increases the z-index of the header element to 999, ensuring it remains above other content.

This change addresses potential layering issues, enhancing the visual hierarchy and user experience.